### PR TITLE
Fix: make it works on worker

### DIFF
--- a/__tests__/react.integration.spec.tsx
+++ b/__tests__/react.integration.spec.tsx
@@ -8,12 +8,12 @@ import {
   createCriticalStyleStream,
   createLink,
   createStyleStream,
-  discoverProjectStyles,
   enableReactOptimization,
   getCriticalStyles,
   getUsedStyles,
   parseProjectStyles,
 } from '../src';
+import { discoverProjectStyles } from '../src/discoverProjectStyles';
 import { StyleDefinition } from '../src/types';
 
 describe('File based css stream', () => {

--- a/src/discoverProjectStyles.ts
+++ b/src/discoverProjectStyles.ts
@@ -1,0 +1,37 @@
+import { readFile } from 'fs';
+import { extname, join, relative } from 'path';
+
+import { promisify } from 'util';
+
+// @ts-ignore
+import scanDirectory from 'scan-directory';
+
+import { loadStyleDefinitions, passAll } from './loadStyleDefinitions';
+import { StyleDefinition } from './types';
+
+const RESOLVE_EXTENSIONS = ['.css'];
+
+const pReadFile = promisify(readFile);
+
+export const getFileContent = (file: string) => pReadFile(file, 'utf8');
+
+/**
+ * auto discovers style files in a given dir applying a given "ordering" filter
+ * @see Use {@link loadStyleDefinitions} as a full customizable variant
+ * @param rootDir - location of the build artefact
+ * @param fileFilter - filter and ordering, return false to skip the file, return true or null to not change file order, sort index otherwise
+ */
+export function discoverProjectStyles(
+  rootDir: string,
+  fileFilter: (fileName: string) => boolean | number | null = passAll
+): StyleDefinition {
+  return loadStyleDefinitions(
+    async () =>
+      ((await scanDirectory(rootDir, undefined, () => false)) as string[])
+        .filter((name) => RESOLVE_EXTENSIONS.indexOf(extname(name)) >= 0)
+        .map((file) => relative(rootDir, file))
+        .sort(),
+    (fileName) => getFileContent(join(rootDir, fileName)),
+    fileFilter
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,11 @@
 import { enableReactOptimization } from './config';
 import { createLink } from './createLink';
+// import { discoverProjectStyles } from './discoverProjectStyles';
 import { getCriticalRules, extractCriticalRules, getCriticalStyles, getUsedStyles } from './getCSS';
+import { loadStyleDefinitions, parseProjectStyles } from './loadStyleDefinitions';
 import { alterProjectStyles } from './operations';
 import { createCriticalStyleStream } from './reporters/critical';
 import { createStyleStream } from './reporters/used';
-import { discoverProjectStyles, loadStyleDefinitions, parseProjectStyles } from './scanForStyles';
 
 import { createUsedFilter as createUsedSelectorsFilter } from './utils/cache';
 
@@ -13,7 +14,7 @@ export { UsedTypes, StyleDefinition, SelectionFilter } from './types';
 export {
   createUsedSelectorsFilter,
   loadStyleDefinitions,
-  discoverProjectStyles,
+  // discoverProjectStyles,
   parseProjectStyles,
   alterProjectStyles,
   getUsedStyles,

--- a/src/loadStyleDefinitions.ts
+++ b/src/loadStyleDefinitions.ts
@@ -1,21 +1,7 @@
-import { readFile } from 'fs';
-import { extname, join, relative } from 'path';
-
-import { promisify } from 'util';
-
-// @ts-ignore
-import scanDirectory from 'scan-directory';
-
 import { StyleAst } from './parser/ast';
 import { buildAst } from './parser/toAst';
 import { StyleDefinition, StyleFiles, StylesLookupTable, SyncStyleDefinition } from './types';
 import { flattenOrder } from './utils/order';
-
-const RESOLVE_EXTENSIONS = ['.css'];
-
-const pReadFile = promisify(readFile);
-
-export const getFileContent = (file: string) => pReadFile(file, 'utf8');
 
 const toFlattenArray = (ast: StyleAst): StylesLookupTable =>
   Object.keys(ast).reduce((acc, file) => {
@@ -53,7 +39,7 @@ export function parseProjectStyles(data: Readonly<StyleFiles>): SyncStyleDefinit
   };
 }
 
-const passAll = () => true;
+export const passAll = () => true;
 
 export interface FlattenFileOrder {
   file: string;
@@ -140,25 +126,4 @@ export function loadStyleDefinitions(
   );
 
   return result;
-}
-
-/**
- * auto discovers style files in a given dir applying a given "ordering" filter
- * @see Use {@link loadStyleDefinitions} as a full customizable variant
- * @param rootDir - location of the build artefact
- * @param fileFilter - filter and ordering, return false to skip the file, return true or null to not change file order, sort index otherwise
- */
-export function discoverProjectStyles(
-  rootDir: string,
-  fileFilter: (fileName: string) => boolean | number | null = passAll
-): StyleDefinition {
-  return loadStyleDefinitions(
-    async () =>
-      ((await scanDirectory(rootDir, undefined, () => false)) as string[])
-        .filter((name) => RESOLVE_EXTENSIONS.indexOf(extname(name)) >= 0)
-        .map((file) => relative(rootDir, file))
-        .sort(),
-    (fileName) => getFileContent(join(rootDir, fileName)),
-    fileFilter
-  );
 }


### PR DESCRIPTION
I have tested it, it works great on worker. All we need is to use `loadStyleDefinitions` and pass the client assets through Couldfare KV for dev/prod. So I split the `loadStyleDefinitions` from `discoverProjectStyles` and omit the later one (which relies on `fs` that doesn't run on worker) (refer to [this issue](https://github.com/theKashey/used-styles/issues/40#issuecomment-1103490151))